### PR TITLE
Upgrade exercise dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ tests/**/.dart_tool/
 tests/**/.packages
 tests/**/pubspec.lock
 tests/**/build.log
+
+/.idea/

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -39,7 +39,7 @@ dart pub upgrade --offline > "${build_log_file}"
 
 # Run the tests for the provided implementation file and redirect stdout and
 # stderr to capture it
-test_output=$(pub run test --run-skipped 2>&1)
+test_output=$(dart test --run-skipped 2>&1)
 exit_code=$?
 
 popd > /dev/null

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -35,7 +35,7 @@ echo "${slug}: testing..."
 
 pushd "${input_dir}" > /dev/null
 
-pub get --offline > "${build_log_file}"
+dart pub upgrade --offline > "${build_log_file}"
 
 # Run the tests for the provided implementation file and redirect stdout and
 # stderr to capture it


### PR DESCRIPTION
The test runner currently uses the dependencies that were first cached who knows how long ago. The Dart SDK has changed and evolved in the last year with support for null safety.

Given that the dependencies needed by the SDK and what was cached can drift apart, the test runner should run the tests like the Dart track using `pub upgrade` or `dart pub upgrade` before executing the tests. This prevents can drift between what the SDK wants and the exercise uses.
