### PR TITLE
Update docker image to dart/2.15.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.14.1
+FROM dart:2.15.1
 
 RUN apt-get update && \
     apt-get install -y jq && \


### PR DESCRIPTION
The docker image used until now, google/dart, is discontinued according
to https://hub.docker.com/r/google/dart

I switched the docker image to the official dart image and updated the
version to 2.15.1